### PR TITLE
Fix for #7 improper handling of 'OK' content in an SMS

### DIFF
--- a/humod/humodem.py
+++ b/humod/humodem.py
@@ -176,7 +176,7 @@ class ModemPort(serial.Serial):
                 
             # Check for errors and raise exception with specific error code.
             errors.check_for_errors(input_line)
-            if input_line == 'OK':
+            if input_line == 'OK' and self.inWaiting() == 0:  # Final 'OK\r\n'
                 return data
             # Append only related data (starting with "command" contents).
             if command:

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,1 +1,0 @@
-import unittest

--- a/tests/test_humodem.py
+++ b/tests/test_humodem.py
@@ -1,0 +1,49 @@
+import unittest
+from mock import Mock
+import serial
+import humod
+
+class MockSerial(serial.serialutil.SerialBase):
+    payload = None
+    def __init__(self, port, baudrate, **kwargs):
+        serial.serialutil.SerialBase.__init__(self, None, baudrate, **kwargs)
+        self.read = Mock()
+        self.write = Mock()
+        self.payload = []
+
+    def inWaiting(self):
+        return sum(len(s) for s in self.payload)
+
+    def readline(self):
+        return self.payload.pop(0)
+
+
+class TestHumod(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        humod.humodem.serial.Serial = MockSerial
+        reload(humod.humodem)
+
+    def setUp(self):
+        self.modem = humod.Modem()
+
+    def test_handle_content_ok(self):
+        self.set_payload([
+            u'CMDOK',
+            u'+CMGL: 0,"REC READ","999222",,"12/05/10,10:05:41+08"\r\n',
+            u'Za Data, Internet Vam bylo odecteno 30.00 Kc.\r\n',
+            u'+CMGL: 1,"REC READ","999222",,"12/05/10,10:05:41+08"\r\n',
+            u'OK\r\n',
+            u'+CMGL: 2,"REC READ","123456",,"12/05/10,09:50:51+08"\r\n',
+            u'Whatever\r\n',
+            u'OK\r\n',
+        ])
+        texts = self.modem.sms_list()
+        self.assertEqual(3, len(texts))
+
+    def set_payload(self, payload):
+        self.modem.ctrl_port.payload = payload
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_humodem.py
+++ b/tests/test_humodem.py
@@ -1,5 +1,10 @@
+import sys
 import unittest
-from mock import Mock
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
+    from imp import reload
 import serial
 import humod
 
@@ -15,7 +20,10 @@ class MockSerial(serial.serialutil.SerialBase):
         return sum(len(s) for s in self.payload)
 
     def readline(self):
-        return self.payload.pop(0)
+        line = self.payload.pop(0)
+        if sys.version_info >= (3, 0):
+            line = bytes(line, 'utf-8')
+        return line
 
 
 class TestHumod(unittest.TestCase):


### PR DESCRIPTION
This probably fixes the issue, as confirmed by a unit test, but I'm unable to functionally test it since I don't have an enabled modem anymore. 

@fmalina I'd appreciate if you could review this change.

Running unit tests is a little awkward since I was too lazy to do the whole distutils/setuptools compatibility thing between py3 and py2, so here is how we do it for now:

This will use the version currently installed (the "before"):

```
~/pyhumod$ python tests/test_humodem.py
```

This will use the version from the branch (the "after"):

```
~/pyhumod$ PYTHONPATH="." python tests/test_humodem.py
```
